### PR TITLE
Ignore non-compliant data from GNOME Virtual FileSystem client

### DIFF
--- a/ftpdlite.py
+++ b/ftpdlite.py
@@ -534,6 +534,8 @@ class FTPdLite:
         Returns:
             boolean: always True
         """
+        if dirpath == "-a":  # Ignore non-compliant data from GNOME Virtual FileSystem
+            dirpath = ""
         dirpath = FTPdLite.decode_path(session.cwd, dirpath, empty_means_cwd=True)
         try:
             dir_entries = listdir(dirpath)


### PR DESCRIPTION
This change allows the FTP client built in to GNU/Linux desktops to succesfully browse ftpdlite